### PR TITLE
Fix error handling for input device

### DIFF
--- a/system76_acpi.c
+++ b/system76_acpi.c
@@ -732,8 +732,10 @@ static int system76_add(struct acpi_device *acpi_dev)
 	input_set_capability(data->input, EV_KEY, KEY_SCREENLOCK);
 
 	err = input_register_device(data->input);
-	if (err)
-		goto error;
+	if (err) {
+		input_free_device(data->input);
+		return err;
+	}
 
 	err = system76_get_object(data, "NFAN", &data->nfan);
 	if (err)
@@ -756,7 +758,6 @@ static int system76_add(struct acpi_device *acpi_dev)
 error:
 	kfree(data->ntmp);
 	kfree(data->nfan);
-	input_free_device(data->input);
 	return err;
 }
 


### PR DESCRIPTION
`input_free_device` only needs to be called if `input_register_device`
failed, not in all error cases. Per `devm_input_allocate_device`
documentation, managed devices do not need to be explicitly unregistered
or freed, so do not add any other cleanup for the device.

Fixes: c169971892d ("Address feedback from upstream")

Resolves: #12