### PR TITLE
Remove custom hwdb

### DIFF
--- a/debian/system76-acpi-dkms.install
+++ b/debian/system76-acpi-dkms.install
@@ -1,2 +1,1 @@
-lib/udev/hwdb.d
 usr/share/initramfs-tools

--- a/lib/udev/hwdb.d/99-system76-acpi-dkms.hwdb
+++ b/lib/udev/hwdb.d/99-system76-acpi-dkms.hwdb
@@ -1,3 +1,0 @@
-evdev:atkbd:dmi:bvn*:bvr*:bd*:svnSystem76*:pn*
- KEYBOARD_KEY_f7=f21
- KEYBOARD_KEY_f8=f21


### PR DESCRIPTION
These entries were upstreamed in systemd/systemd@a08c8c17da08 ("Add System76 touchpad toggle support").